### PR TITLE
update links to use BE product service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This is frontend starter project for nodejs-aws mentoring program. It uses the f
 - [CloudFront URL](https://d2sannh3qnvxga.cloudfront.net/)
 - [S3 URL](https://deployshopstack-deploymentfrontendbucket67ceb713-x5yrgmjjnujh.s3.eu-north-1.amazonaws.com/index.html)
 
+## Backend
+
+- [API Gateway URL](https://uz5grq0ue2.execute-api.eu-north-1.amazonaws.com/prod/)
+
 ## Available Scripts
 
 ### `start`

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,8 +1,8 @@
 const API_PATHS = {
-  product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  product: "https://uz5grq0ue2.execute-api.eu-north-1.amazonaws.com/prod",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: "https://uz5grq0ue2.execute-api.eu-north-1.amazonaws.com/prod",
   cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
 };
 

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.bff}/products`
       );
       return res.data;
     }


### PR DESCRIPTION
- API Gateway for product service is deployed
- updated links in the FE shop app to use the API Gateway

CloudFront URL: https://d2sannh3qnvxga.cloudfront.net/
API Gateway URL: https://uz5grq0ue2.execute-api.eu-north-1.amazonaws.com/prod/

Corresponding MR to the BE repo:
https://github.com/set3228/shop-react-backend/pull/1

![image](https://github.com/user-attachments/assets/9fa1f75c-f8ac-44e5-9ed8-45a9b18e5458)
![image](https://github.com/user-attachments/assets/6fb34b88-f186-4553-a32a-f73169d08f39)
