### PR TITLE
add basic authorization

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -38,6 +38,9 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       params: {
         name: encodeURIComponent(file.name),
       },
+      headers: {
+        Authorization: `Basic ${localStorage.getItem('authorization_token')}`,
+      },
     });
     console.log('File to upload: ', file.name);
     console.log('Uploading to: ', response.data);


### PR DESCRIPTION
a basic authorization is added on BE for /import endpoint
the FE uses `Authorization` header for uploading csv

![image](https://github.com/user-attachments/assets/eeda6857-8c73-4286-aef8-dee00228904d)

access permission and CORS issues are solved

related BE PR - https://github.com/set3228/shop-react-backend/pull/5

